### PR TITLE
Remove teste duplicado do arquivo `tabnews.spec.ts`

### DIFF
--- a/src/tabnews.spec.ts
+++ b/src/tabnews.spec.ts
@@ -6,7 +6,7 @@ import { TABNEWS_HEADERS } from './commons';
 import { TabNews } from './tabnews';
 
 describe('TabNews', () => {
-  it('should instantiate without and without env', () => {
+  it('should instantiate without credentials and without env', () => {
     const tabNews = new TabNews();
 
     expect(tabNews.config.credentials?.email).toBeUndefined();
@@ -23,17 +23,6 @@ describe('TabNews', () => {
     expect(tabNews.config.credentials?.password).toBe('env_dummy_password');
 
     vi.unstubAllEnvs();
-  });
-
-  it('should instantiate with config', () => {
-    const tabNews = new TabNews({
-      credentials: {
-        email: 'test@email.com',
-        password: 'dummy_password',
-      },
-    });
-    expect(tabNews.config.credentials?.email).toBe('test@email.com');
-    expect(tabNews.config.credentials?.password).toBe('dummy_password');
   });
 
   it('should instantiate with config', () => {


### PR DESCRIPTION
Fala @leoferreiralima :handshake: 

Esta PR remove o teste duplicado que mencionei na issue #51. Além disso, também renomeei a mensagem do outro teste que comentei lá :+1:

---

Em paralelo, quando rodei o script de `commit` recebi o seguinte aviso sobre o `.husky`:

![image](https://github.com/leoferreiralima/tabnews-sdk/assets/57193392/03983547-ae9a-4c02-aa45-c90704b83cc6)

Achei estranho porque ele foi instalado normalmente:

![image](https://github.com/leoferreiralima/tabnews-sdk/assets/57193392/9b0f4546-dbdf-4f51-b9c6-a9ec29dd6938)
